### PR TITLE
fix: redirecting to homepage on click

### DIFF
--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -43,8 +43,7 @@ export const SiteHeader = () => (
               sound="click"
             >
               <Link
-                href="https://shadcn-labs.com"
-                target="_blank"
+                href="/"
                 rel="noopener noreferrer"
               >
                 <LogoMark className="size-5" />


### PR DESCRIPTION
### Summary

The corresponding issue is this: [Issue-27](https://github.com/shadcn-labs/editorcn/issues/27)

The problem was the `href`-tag pointing to the specific adress, not the home-page. This was changed.

### Validation

I manually checked this. I know, testing...

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I added tests and documentation where relevant
- [x] I ran `turbo typecheck` and `turbo lint` successfully
